### PR TITLE
회원가입 시작하기 버튼 -> 홈화면으로 이동

### DIFF
--- a/TUDY.xcodeproj/project.pbxproj
+++ b/TUDY.xcodeproj/project.pbxproj
@@ -42,6 +42,7 @@
 		D87CBB5A284477D4003397A5 /* SubwayDataManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D87CBB59284477D4003397A5 /* SubwayDataManager.swift */; };
 		D893D318283B2EBC0057075F /* UIColor+Custom.swift in Sources */ = {isa = PBXBuildFile; fileRef = D893D317283B2EBC0057075F /* UIColor+Custom.swift */; };
 		D893D31B283B2F550057075F /* SignUpError.swift in Sources */ = {isa = PBXBuildFile; fileRef = D893D31A283B2F550057075F /* SignUpError.swift */; };
+		D8C53A80284B595D000E7170 /* LoginCoordinatorDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8C53A7F284B595D000E7170 /* LoginCoordinatorDelegate.swift */; };
 		D8C7F221283B582B00424AE5 /* CoordinatorProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8C7F220283B582B00424AE5 /* CoordinatorProtocol.swift */; };
 		D8C7F225283B5ABD00424AE5 /* AppCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8C7F224283B5ABD00424AE5 /* AppCoordinator.swift */; };
 		D8C7F227283B628600424AE5 /* TabBarPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8C7F226283B628600424AE5 /* TabBarPage.swift */; };
@@ -113,6 +114,7 @@
 		D87CBB59284477D4003397A5 /* SubwayDataManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubwayDataManager.swift; sourceTree = "<group>"; };
 		D893D317283B2EBC0057075F /* UIColor+Custom.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+Custom.swift"; sourceTree = "<group>"; };
 		D893D31A283B2F550057075F /* SignUpError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpError.swift; sourceTree = "<group>"; };
+		D8C53A7F284B595D000E7170 /* LoginCoordinatorDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginCoordinatorDelegate.swift; sourceTree = "<group>"; };
 		D8C7F220283B582B00424AE5 /* CoordinatorProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoordinatorProtocol.swift; sourceTree = "<group>"; };
 		D8C7F224283B5ABD00424AE5 /* AppCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppCoordinator.swift; sourceTree = "<group>"; };
 		D8C7F226283B628600424AE5 /* TabBarPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarPage.swift; sourceTree = "<group>"; };
@@ -451,6 +453,7 @@
 		D85ED4C6283E681100D0A006 /* Login */ = {
 			isa = PBXGroup;
 			children = (
+				D8C53A7F284B595D000E7170 /* LoginCoordinatorDelegate.swift */,
 				D85ED4CA283E68CC00D0A006 /* LoginCoordinatorProtocol.swift */,
 				D85ED4CC283E68DA00D0A006 /* LoginCoordinator.swift */,
 			);
@@ -771,6 +774,7 @@
 				4A6E64FB2837888300B954B9 /* SearchTableViewCell.swift in Sources */,
 				D87CBB4A28432075003397A5 /* JobCell.swift in Sources */,
 				D87CBB5428439F4B003397A5 /* DetailJobButton.swift in Sources */,
+				D8C53A80284B595D000E7170 /* LoginCoordinatorDelegate.swift in Sources */,
 				FFD4624C2834BB13002A2022 /* HomeViewController.swift in Sources */,
 				D847E0042840B9F700BB4E08 /* UIToolbar+Custom.swift in Sources */,
 				D8C7F22F283B726400424AE5 /* CoordinatorType.swift in Sources */,

--- a/TUDY/Presentations/Signup/TUDY/Presentations/Signup/ViewController/WelcomeViewController.swift
+++ b/TUDY/Presentations/Signup/TUDY/Presentations/Signup/ViewController/WelcomeViewController.swift
@@ -42,6 +42,7 @@ extension WelcomeViewController {
         view.addSubview(startButton)
         startButton.addTarget(self, action: #selector(start), for: .touchUpInside)
         startButton.nextButtonLayout(view: view)
+        startButton.changeIsEnabledTrue()
     }
     
     @objc private func start() {

--- a/TUDY/Util/Coordinator/Home/HomeCoordinator.swift
+++ b/TUDY/Util/Coordinator/Home/HomeCoordinator.swift
@@ -35,6 +35,10 @@ final class HomeCoordinator: HomeCoordinatorProtocol {
         }
         self.navigationController.pushViewController(self.homeViewController, animated: true)
     }
+    
+    deinit {
+        print("Home Coordinaotr deinit")
+    }
 }
 
 // MARK: - HomeCoordinatorProtocol

--- a/TUDY/Util/Coordinator/Login/LoginCoordinator.swift
+++ b/TUDY/Util/Coordinator/Login/LoginCoordinator.swift
@@ -11,7 +11,8 @@ final class LoginCoordinator: LoginCoordinatorProtocol {
     
     var loginViewController: LoginViewController
     
-    var finishDelegate: CoordinatorFinishDelegate?
+    weak var finishDelegate: CoordinatorFinishDelegate?
+    weak var loginCoordinatorDelegate: LoginCoordinatorDelegate?
     var navigationController: UINavigationController
     var childCoordinators: [Coordinator] = []
     var type: CoordinatorType = .login
@@ -55,10 +56,6 @@ extension LoginCoordinator {
         navigationController.pushViewController(setNameViewController, animated: true)
     }
     
-    func show() {
-        
-    }
-    
     func showSetInterestedJobViewController() {
         let setInterestedJobViewController = SetInterestedJobViewController()
         setInterestedJobViewController.didSendEventClosure = { [weak self] event in
@@ -79,7 +76,9 @@ extension LoginCoordinator {
     
     func showWelcomeViewController() {
         let welcomeViewController = WelcomeViewController()
-        // 메인으로
+        welcomeViewController.didSendEventClosure = { [weak self] event in
+            self?.loginCoordinatorDelegate?.showHomeCoordinator()
+        }
         
         navigationController.pushViewController(welcomeViewController, animated: true)
     }

--- a/TUDY/Util/Coordinator/Login/LoginCoordinatorDelegate.swift
+++ b/TUDY/Util/Coordinator/Login/LoginCoordinatorDelegate.swift
@@ -1,0 +1,12 @@
+//
+//  LoginCoordinatorDelegate.swift
+//  TUDY
+//
+//  Created by neuli on 2022/06/04.
+//
+
+import Foundation
+
+protocol LoginCoordinatorDelegate: AnyObject {
+    func showHomeCoordinator()
+}

--- a/TUDY/Util/Coordinator/Tap/TabCoordinator.swift
+++ b/TUDY/Util/Coordinator/Tap/TabCoordinator.swift
@@ -36,6 +36,7 @@ extension TabCoordinator {
     func showLogin() {
         let loginCoordinator = LoginCoordinator(navigationController)
         loginCoordinator.finishDelegate = self
+        loginCoordinator.loginCoordinatorDelegate = self
         loginCoordinator.start()
         childCoordinators.append(loginCoordinator)
     }
@@ -89,10 +90,18 @@ extension TabCoordinator {
     }
 }
 
-// MARK: - CoordinatorFinishDelegate
+// MARK: - HomeCoordinatorDelegate
 extension TabCoordinator: HomeCoordinatorDelegate {
     func prepareLoginCoordinator(_ coordinator: HomeCoordinator) {
         self.showLogin()
+    }
+}
+
+// MARK: - LoginCoordinatorDelegate
+extension TabCoordinator: LoginCoordinatorDelegate {
+    func showHomeCoordinator() {
+        self.childCoordinators.removeAll()
+        self.start()
     }
 }
 


### PR DESCRIPTION
## 작업사항
- 상운님 요청사항으로 회원가입 마지막 시작하기 버튼 눌렀을 때 홈화면으로 이동하는 코드 추가했습니다.
- 근데 애니메이션 효과 없이 그냥 띡 나타나서.. 고민좀 해봐야겠네요

- 이동 방법은

1. 원래 처음 TapCoordinator에서 홈 코디네이터랑 채팅 코디네이터를 생성해서 홈 코디네이터를 보여줍니다.
2. 만약 로그인이 안되어있는 상태에서 글작성을(기타등등) 하려고 하면 홈 코디네이터에서 탭 코디네이터로 로그인 코디네이터 생성해서 보여줘 요청을 합니다.
3. 이때 홈 코디네이터를 삭제하지 않고 로그인 코디네이터를 생성해서 보여주는데요, 왜냐하면 로그인화면에서 `로그인없이 둘러보기` 버튼을 누르면 이전 홈화면을 그대로 보여줘야하기 때문입니다. (검색 화면 등등) 
4. 이제 로그인 코디네이터에서 로그인을 하고 회원가입 페이지를 모두 완료하고 시작하기 버튼을 누르면 로그인 코디네이터에서 탭 코디네이터로 로그인 회원가입 끝났으니까 홈화면 보여줘 요청을 합니다.
5. 이때 로그인 코디네이터에서 finish() 함수를 호출하면 로그인 코디네이터가 deinit 되고 네비게이션 컨트롤러는 한번만 pop된 상태로 돌아가더라구요..
6. 그래서 탭 코디네이터에 홈화면 보여줘 요청을 하면 탭 코디네이터에서 자식 코디네이터들 (로그인, 홈, 채팅) 을 모두 삭제하고 홈, 채팅 코디네이터를 다시 생성해서 보여줍니다. (애니메이션 없음..! 살짝 부자연스러움)


글밖에 없어서 눈에 들어오실지 모르겠네요.. 다시 물어봐주시면 답해드리겠습니다 ㅜㅜ
코디네이터 구성도는 다음에 다시 그려볼게요
