### PR TITLE
회원가입시 User FireStore에 저장

### DIFF
--- a/TUDY/Models/User.swift
+++ b/TUDY/Models/User.swift
@@ -8,36 +8,56 @@
 import Foundation
 
 struct User: Codable {
-    var userId: Int
-    var signUpDate: Int
+    var userID: String
+    var signUpDate: String
     var nickname: String
-    var profileImage: String
-    var interestedJob: [String] // job 구조체
-    var subways: String // 지하철 구조체
-    var likeProjectId: String?
-    var personalChat: [String]?
-    var groupChat: [String]?
+    var profileImageURL: String
+    var interestedJob: String
+    var interestedDetailJobs: [String]
+    var subwayStation: String
+    var subwayLines: [String]
+    var likeProjectIDs: [String]
+    var personalChatIDs: [String]
+    var groupChatIDs: [String]
     
     init (
-        userId: Int = 0,
-        signUpDate: Int = 0,
+        userID: String = "",
+        signUpDate: String = "",
         nickname: String = "",
-        profileImage: String = "",
-        interestedJob: [String] = [],
-        subways: String = "",
-        likeProjectId: String = "",
-        personalChat: [String] = [],
-        groupChat: [String] = []
+        profileImageURL: String = "",
+        interestedJob: String = "",
+        interestedDetailJobs: [String] = [],
+        subwayStation: String = "",
+        subwayLines: [String] = [],
+        likeProjectIDs: [String] = [],
+        personalChatIDs: [String] = [],
+        groupChatIDs: [String] = []
     ) {
-        self.userId = userId
+        self.userID = userID
         self.signUpDate = signUpDate
         self.nickname = nickname
-        self.profileImage = profileImage
+        self.profileImageURL = profileImageURL
         self.interestedJob = interestedJob
-        self.subways = subways
-        self.likeProjectId = likeProjectId
-        self.personalChat = personalChat
-        self.groupChat = groupChat
+        self.interestedDetailJobs = interestedDetailJobs
+        self.subwayStation = subwayStation
+        self.subwayLines = subwayLines
+        self.likeProjectIDs = likeProjectIDs
+        self.personalChatIDs = personalChatIDs
+        self.groupChatIDs = groupChatIDs
+    }
+    
+    init(dict: [String : Any]) {
+        self.userID = dict["userID"] as? String ?? ""
+        self.signUpDate = dict["signUpDate"] as? String ?? ""
+        self.nickname = dict["nickname"] as? String ?? ""
+        self.profileImageURL = dict["profileImageURL"] as? String ?? ""
+        self.interestedJob = dict["interestedJob"] as? String ?? ""
+        self.interestedDetailJobs = dict["interestedDetailJobs"] as? [String] ?? []
+        self.subwayStation = dict["subwayStation"] as? String ?? ""
+        self.subwayLines = dict["subwayLines"] as? [String] ?? []
+        self.likeProjectIDs = dict["likeProjectIDs"] as? [String] ?? []
+        self.personalChatIDs = dict["personalChatIDs"] as? [String] ?? []
+        self.groupChatIDs = dict["groupChatIDs"] as? [String] ?? []
     }
 }
 
@@ -49,4 +69,9 @@ extension Encodable {
               let dictinoary = try? JSONSerialization.jsonObject(with: object, options: []) as? [String: Any] else { return nil }
         return dictinoary
     }
+}
+
+struct UserForRegister {
+    static var shared: User = User()
+    private init() {}
 }

--- a/TUDY/Network/CommonFirebaseDatabaseNetworkService.swift
+++ b/TUDY/Network/CommonFirebaseDatabaseNetworkService.swift
@@ -9,21 +9,51 @@ import Foundation
 import Firebase
 import FirebaseFirestore
 
-final class CommonFirebaseDatabaseNetworkServiceClass {
+struct CommonFirebaseDatabaseNetworkService {
     
     private var documentListener: ListenerRegistration?
-
-    func save(_ user: User, completion: ((Error?) -> Void)? = nil) {
+    
+    static func getUserID() -> String {
+        guard let userID = Auth.auth().currentUser?.uid else { fatalError() }
+        return userID
+    }
+    
+    static func save(_ user: User, completion: ((Error?) -> Void)? = nil) {
+        
+        var user = user
+        user.userID = getUserID()
+        user.signUpDate = Date().description
         
         let collectionPath = "/USER"
-        let collectionListener = Firestore.firestore().collection(collectionPath)
-            
-            guard let dictionary = user.asDictionary else {
-                print("decode error")
+        let collectionListener = Firestore.firestore().collection(collectionPath).document(user.userID)
+        
+        guard let dictionary = user.asDictionary else {
+            print("decode error")
+            return
+        }
+        collectionListener.setData(dictionary) { error in
+            if let error = error {
+                print("파이어베이스 저장 에러 \(error.localizedDescription)")
+            }
+        }
+//        collectionListener.addDocument(data: dictionary) { error in
+//            completion?(error)
+//        }
+    }
+    
+    static func fetchUser(completion: @escaping([User]) -> Void) {
+        var users: [User] = []
+        Firestore.firestore().collection("USER").getDocuments { snapshot, error in
+            if let error = error {
+                print("DEBUG: 유저정보 가져오기 실패 \(error.localizedDescription)")
                 return
             }
-        collectionListener.addDocument(data: dictionary) { error in
-            completion?(error)
+            snapshot?.documents.forEach({ document in
+                let dict = document.data()
+                let user = User(dict: dict)
+                users.append(user)
+            })
+            completion(users)
         }
     }
 }

--- a/TUDY/Presentations/Home/ViewController/HomeViewController.swift
+++ b/TUDY/Presentations/Home/ViewController/HomeViewController.swift
@@ -73,18 +73,6 @@ class HomeViewController: UIViewController {
     // MARK: - Life Cycle
     override func viewDidLoad() {
         super.viewDidLoad()
-        print("=================BEFORE===================")
-        var user = User(userId: 123, signUpDate: 456, nickname: "호진", profileImage: "123", interestedJob: ["123","123"], subways: "123", likeProjectId: "123", personalChat: ["123","123"], groupChat: ["123","123"])
-        let A = CommonFirebaseDatabaseNetworkServiceClass()
-        
-        A.save(user) { error in
-            if let error = error {
-                print("error : \(error)")
-                print("ERROR!!!!!!")
-            }
-        }
-        print("=================AFTER===================")
-        
         configureCollectionView()
         configureDataSource()
         configureUI()

--- a/TUDY/Presentations/Signup/TUDY/Presentations/Signup/ViewController/SetInterestedJobViewController.swift
+++ b/TUDY/Presentations/Signup/TUDY/Presentations/Signup/ViewController/SetInterestedJobViewController.swift
@@ -96,6 +96,12 @@ extension SetInterestedJobViewController {
         navigationController?.setNavigationBarHidden(false, animated: true)
     }
     
+    private func setUser() {
+        guard let interestedJob = selectedJob?.rawValue else { fatalError() }
+        UserForRegister.shared.interestedJob = interestedJob
+        UserForRegister.shared.interestedDetailJobs = selectedDetailJobs
+    }
+    
     // MARK: CollectionView
     
     func collectionViewLayout(height: CGFloat) -> UICollectionViewLayout {
@@ -226,6 +232,7 @@ extension SetInterestedJobViewController {
     
     // MARK: - Action Methods
     @objc private func goNext() {
+        setUser()
         didSendEventClosure?(.next)
     }
     

--- a/TUDY/Presentations/Signup/TUDY/Presentations/Signup/ViewController/SetNameViewController.swift
+++ b/TUDY/Presentations/Signup/TUDY/Presentations/Signup/ViewController/SetNameViewController.swift
@@ -130,6 +130,11 @@ extension SetNameViewController {
         nameTextField.rightView = noSeeButton
     }
     
+    private func setUser() {
+        guard let nickname = nameTextField.text else { return }
+        UserForRegister.shared.nickname = nickname
+    }
+    
     // MARK: - Action Methods
     @objc private func checkNameValidation() {
         // 정규식으로 이름 유효성 체크
@@ -152,6 +157,7 @@ extension SetNameViewController {
     }
     
     @objc private func goNext() {
+        setUser()
         didSendEventClosure?(.next)
     }
     

--- a/TUDY/Presentations/Signup/TUDY/Presentations/Signup/ViewController/SetSubwayViewController.swift
+++ b/TUDY/Presentations/Signup/TUDY/Presentations/Signup/ViewController/SetSubwayViewController.swift
@@ -28,8 +28,6 @@ class SetSubwayViewController: UIViewController {
     
     private let subwayTextField = UITextField().textField(withPlaceholder: "지하철명을 초성 혹은 단어로 검색하세요.")
     private let signUpButton = UIButton().nextButton(text: "가입하기")
-    private let signUpToolbarButton = UIButton().nextButton(text: "가입하기")
-    private let signUpToolbar = UIToolbar().toolbar()
     
     // 지하철 선택 view
     private typealias DataSource = UICollectionViewDiffableDataSource<Int, Subway>
@@ -100,13 +98,6 @@ extension SetSubwayViewController {
         view.addSubview(signUpButton)
         signUpButton.addTarget(self, action: #selector(goNext), for: .touchUpInside)
         signUpButton.nextButtonLayout(view: view)
-        
-        let signUpBarButtonItem = UIBarButtonItem(customView: signUpToolbarButton)
-        signUpToolbarButton.addTarget(self, action: #selector(goNext), for: .touchUpInside)
-        signUpToolbar.frame = CGRect(x: 0, y: view.frame.size.height - 50, width: view.frame.size.width, height: 50)
-        signUpToolbar.items = [signUpBarButtonItem]
-        signUpToolbar.updateConstraintsIfNeeded()
-        subwayTextField.inputAccessoryView = signUpToolbar
     }
     
     private func setNavigationBar() {
@@ -125,14 +116,16 @@ extension SetSubwayViewController {
     
     private func buttonChangeEnableTrue() {
         signUpButton.changeIsEnabledTrue()
-        signUpToolbarButton.changeIsEnabledTrue()
-        signUpToolbar.changeColorDarkGray4()
     }
     
     private func buttonChangeEnableFalse() {
         signUpButton.changeIsEnabledFalse()
-        signUpToolbarButton.changeIsEnabledFalse()
-        signUpToolbar.changeColorDarkGray2()
+    }
+    
+    private func setUser(_ subway: Subway) {
+        // 유저 지하철 정보 저장
+        UserForRegister.shared.subwayStation = subway.station
+        UserForRegister.shared.subwayLines = subway.lines
     }
     
     // MARK: CollectionView
@@ -278,8 +271,9 @@ extension SetSubwayViewController: UICollectionViewDelegate {
         subwayTextField.text = selectedSubwayStation.station
         
         filteredSubwayList = []
-        updateSnapshot()
         
+        setUser(selectedSubwayStation)
+        updateSnapshot()
         buttonChangeEnableTrue()
     }
 }

--- a/TUDY/Presentations/Signup/TUDY/Presentations/Signup/ViewController/WelcomeViewController.swift
+++ b/TUDY/Presentations/Signup/TUDY/Presentations/Signup/ViewController/WelcomeViewController.swift
@@ -46,6 +46,11 @@ extension WelcomeViewController {
     }
     
     @objc private func start() {
+        CommonFirebaseDatabaseNetworkService.save(UserForRegister.shared) { error in
+            if let error = error {
+                print("유저 정보 DB 저장 실패 : \(error.localizedDescription)")
+            }
+        }
         didSendEventClosure?(.start)
     }
 }


### PR DESCRIPTION
## 개요
- #23 

## 작업사항
- 회원가입 시 Firestore Database에 User 정보 추가했습니다.

## 변경로직(optional)
- User 구조체를 조금 바꿨는데 
    - 우선 네이밍에서 Ids로 적는 것 보다 IDs 로 적는게 일기가 편한 것 같아 IDs로 변경하였습니다.
    - 직무선택과 지하철 선택은 각각 직업, 세부직업들, 지하철 이름, 지하철 라인들 로 변경하였습니다.
    - `userID`와 회원가입일시는 `String`으로 변경하였습니다.
    - `UserForRegister` 구조체는 따로 뺄까하다가 회원가입시 한번만 사용하는 singleton 객체라서 `User` 파일 안에 넣어두었습니다.
    - `UserForRegister` 만든이유는 회원가입 뷰컨이 여러개라 클로저로 계속 데이터를 넘겨주는 것보단 싱글톤으로 각자 접근하는게 구현하기 쉬울 것 같아서 만들었습니다.

- `CommonFirebaseDatabaseNetworkServiceClass` 파일을 구조체로 변경하고 이름을 `CommonFirebaseDatabaseNetworkService`로 변경하였습니다.
    - 왜냐하면 상속을 받지 않기떄문에 가벼운 구조체로 변경했습니다.
    - 구조체로 변경 후 함수들을 static으로 변경해서 바로 호출 가능하도록 했습니다.

- `CommonFirebaseDatabaseNetworkService.getUserID()` 함수로 uid를 가져올 수 있습니다.

- `CommonFirebaseDatabaseNetworkService` 에서 유저 저장할때 (`save()` 함수) uid로 저장을 하고 싶어서 코드를 조금 바꿔보았습니다.

<img width="872" alt="image" src="https://user-images.githubusercontent.com/39167842/172373434-391ffe3e-46c4-49fc-992f-a648f5b79cc7.png">
<img width="859" alt="image" src="https://user-images.githubusercontent.com/39167842/172373346-98d93588-b394-47e3-92db-525b1b2ece6d.png">