### PR TITLE
이미지 저장, 불러오기

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -11,10 +11,11 @@ target 'TUDY' do
   pod 'Firebase/Auth'
   pod 'Firebase/Database'
   pod 'Firebase/Firestore'
-  pod 'FirebaseFirestore'
+  pod 'FirebaseStorage'
   pod 'GoogleSignIn'
   pod 'KakaoSDKCommon'  # 필수 요소를 담은 공통 모듈
   pod 'KakaoSDKAuth'  # 사용자 인증
   pod 'KakaoSDKUser'  # 카카오 로그인, 사용자 관리
+  pod 'SDWebImage', '~> 5.0' # 이미지
 
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -676,6 +676,9 @@ PODS:
     - GoogleUtilities/Environment (~> 7.7)
     - GoogleUtilities/UserDefaults (~> 7.7)
     - PromisesObjC (< 3.0, >= 1.2)
+  - FirebaseStorage (8.15.0):
+    - FirebaseCore (~> 8.0)
+    - GTMSessionFetcher/Core (~> 1.5)
   - GoogleAppMeasurement (8.15.0):
     - GoogleAppMeasurement/AdIdSupport (= 8.15.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 7.7)
@@ -802,6 +805,9 @@ PODS:
   - nanopb/decode (2.30908.0)
   - nanopb/encode (2.30908.0)
   - PromisesObjC (2.1.0)
+  - SDWebImage (5.12.6):
+    - SDWebImage/Core (= 5.12.6)
+  - SDWebImage/Core (5.12.6)
   - SnapKit (5.6.0)
 
 DEPENDENCIES:
@@ -809,11 +815,12 @@ DEPENDENCIES:
   - Firebase/Core
   - Firebase/Database
   - Firebase/Firestore
-  - FirebaseFirestore
+  - FirebaseStorage
   - GoogleSignIn
   - KakaoSDKAuth
   - KakaoSDKCommon
   - KakaoSDKUser
+  - SDWebImage (~> 5.0)
   - SnapKit (~> 5.6.0)
 
 SPEC REPOS:
@@ -830,6 +837,7 @@ SPEC REPOS:
     - FirebaseDatabase
     - FirebaseFirestore
     - FirebaseInstallations
+    - FirebaseStorage
     - GoogleAppMeasurement
     - GoogleDataTransport
     - GoogleSignIn
@@ -845,6 +853,7 @@ SPEC REPOS:
     - Libuv-gRPC
     - nanopb
     - PromisesObjC
+    - SDWebImage
     - SnapKit
 
 SPEC CHECKSUMS:
@@ -860,6 +869,7 @@ SPEC CHECKSUMS:
   FirebaseDatabase: f567afd233e54a303d84423207736590a6feb419
   FirebaseFirestore: d7023faff8e1b4fd69d0adbcf18e65129bc03842
   FirebaseInstallations: 40bd9054049b2eae9a2c38ef1c3dd213df3605cd
+  FirebaseStorage: 8019af461599b2c3bc61c6a5dbdfa3d2de66a4d9
   GoogleAppMeasurement: 4c19f031220c72464d460c9daa1fb5d1acce958e
   GoogleDataTransport: 629c20a4d363167143f30ea78320d5a7eb8bd940
   GoogleSignIn: c90b5bec45e780f54c6a8e1e3c182a86e3dda69d
@@ -875,8 +885,9 @@ SPEC CHECKSUMS:
   Libuv-gRPC: 55e51798e14ef436ad9bc45d12d43b77b49df378
   nanopb: a0ba3315591a9ae0a16a309ee504766e90db0c96
   PromisesObjC: 99b6f43f9e1044bd87a95a60beff28c2c44ddb72
+  SDWebImage: a47aea9e3d8816015db4e523daff50cfd294499d
   SnapKit: e01d52ebb8ddbc333eefe2132acf85c8227d9c25
 
-PODFILE CHECKSUM: b5a9a91a76c37017c898c257d2fb671beefbf08d
+PODFILE CHECKSUM: ee0b7d0c09ef2912b02d4dcb4d4a1616df36b9f2
 
 COCOAPODS: 1.11.3

--- a/TUDY/Repositories/FirebaseStorage.swift
+++ b/TUDY/Repositories/FirebaseStorage.swift
@@ -7,8 +7,31 @@
 
 import Foundation
 
-import FirebaseFirestore
+import FirebaseStorage
 
 struct FirebaseStorage {
     
+    /// 이미지 저장 함수 (FireStorage)
+    /// 이미지 전달 시 completion handler로 저장된 이미지 URL을 전달해줍니다.
+    static func saveImage(image: UIImage, completion: @escaping (String) -> Void) {
+        guard let imageData = image.jpegData(compressionQuality: 0.3) else { return }
+        
+        let filename = UUID().uuidString
+        let ref = Storage.storage().reference(withPath: "/images/\(filename)")
+        
+        ref.putData(imageData, metadata: nil) { meta, error in
+            if let error = error {
+                print("[DEBUG] 이미지 저장 실패 \(error.localizedDescription)")
+                return
+            }
+            
+            ref.downloadURL { url, error in
+                if let error = error {
+                    print("[DEBUG] 이미지 url 다운로드 실패 \(error.localizedDescription)")
+                }
+                guard let imageURL = url?.absoluteString else { return }
+                completion(imageURL)
+            }
+        }
+    }
 }


### PR DESCRIPTION
## 개요
- #101 

## 작업사항
- `FireStorage`, `SDWebImage` Pod 추가
- 이미지 저장함수 추가

- _**completion handler로 저장된 url을 받아서 DB에 저장해주세요**_

- SDWebImage 사용방법

```Swift
import SDWebImage
guard let url = URL(string: user.profileImageUrl) else { return }
profileImageView.sd_setImage(with: url)
```

- SDWebImage 사용이유
    - 캐시 구현시간 부족
    - SDWebImage, kingfisher, AlamofireImage 중 star 수가 제일 높아서.. ㅎ
    - 세가지 라이브러리 비교    [참고](https://gist.github.com/linearhw/a0677b967b741abf9b8a903c37d3bcc9)
    - 후에 리팩토링 기간에 여유가 되면 캐시 구현을 직접 해봅시다..

## 변경로직(optional)
- **이미지의 UUID를 직접 만들어주지 않고 UIImage만 함수의 파라미터로 넣고 completion handler로 url을 받아서 사용해주세요**
