### PR TITLE
푸시알림 FCM 토큰 저장 추가

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -10,6 +10,7 @@ target 'TUDY' do
   pod 'Firebase/Core'
   pod 'Firebase/Auth'
   pod 'Firebase/Firestore'
+  pod 'Firebase/Messaging'
   pod 'GoogleSignIn'
   pod 'KakaoSDKCommon'  # 필수 요소를 담은 공통 모듈
   pod 'KakaoSDKAuth'  # 사용자 인증

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -620,6 +620,9 @@ PODS:
   - Firebase/Firestore (8.15.0):
     - Firebase/CoreOnly
     - FirebaseFirestore (~> 8.15.0)
+  - Firebase/Messaging (8.15.0):
+    - Firebase/CoreOnly
+    - FirebaseMessaging (~> 8.15.0)
   - FirebaseAnalytics (8.15.0):
     - FirebaseAnalytics/AdIdSupport (= 8.15.0)
     - FirebaseCore (~> 8.0)
@@ -670,6 +673,15 @@ PODS:
     - GoogleUtilities/Environment (~> 7.7)
     - GoogleUtilities/UserDefaults (~> 7.7)
     - PromisesObjC (< 3.0, >= 1.2)
+  - FirebaseMessaging (8.15.0):
+    - FirebaseCore (~> 8.0)
+    - FirebaseInstallations (~> 8.0)
+    - GoogleDataTransport (~> 9.1)
+    - GoogleUtilities/AppDelegateSwizzler (~> 7.7)
+    - GoogleUtilities/Environment (~> 7.7)
+    - GoogleUtilities/Reachability (~> 7.7)
+    - GoogleUtilities/UserDefaults (~> 7.7)
+    - nanopb (~> 2.30908.0)
   - GoogleAppMeasurement (8.15.0):
     - GoogleAppMeasurement/AdIdSupport (= 8.15.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 7.7)
@@ -802,6 +814,7 @@ DEPENDENCIES:
   - Firebase/Auth
   - Firebase/Core
   - Firebase/Firestore
+  - Firebase/Messaging
   - GoogleSignIn
   - KakaoSDKAuth
   - KakaoSDKCommon
@@ -821,6 +834,7 @@ SPEC REPOS:
     - FirebaseCoreDiagnostics
     - FirebaseFirestore
     - FirebaseInstallations
+    - FirebaseMessaging
     - GoogleAppMeasurement
     - GoogleDataTransport
     - GoogleSignIn
@@ -850,6 +864,7 @@ SPEC CHECKSUMS:
   FirebaseCoreDiagnostics: 92e07a649aeb66352b319d43bdd2ee3942af84cb
   FirebaseFirestore: d7023faff8e1b4fd69d0adbcf18e65129bc03842
   FirebaseInstallations: 40bd9054049b2eae9a2c38ef1c3dd213df3605cd
+  FirebaseMessaging: 5e5118a2383b3531e730d974680954c679ca0a13
   GoogleAppMeasurement: 4c19f031220c72464d460c9daa1fb5d1acce958e
   GoogleDataTransport: 629c20a4d363167143f30ea78320d5a7eb8bd940
   GoogleSignIn: c90b5bec45e780f54c6a8e1e3c182a86e3dda69d
@@ -867,6 +882,6 @@ SPEC CHECKSUMS:
   PromisesObjC: 99b6f43f9e1044bd87a95a60beff28c2c44ddb72
   SnapKit: e01d52ebb8ddbc333eefe2132acf85c8227d9c25
 
-PODFILE CHECKSUM: f36809f2828f8914d31b4dc828a1db9046f0e855
+PODFILE CHECKSUM: 08122eacea5d542dabcbebabe48cb7ca5e2c0018
 
 COCOAPODS: 1.11.2

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -679,9 +679,6 @@ PODS:
     - GoogleUtilities/Environment (~> 7.7)
     - GoogleUtilities/UserDefaults (~> 7.7)
     - PromisesObjC (< 3.0, >= 1.2)
-  - FirebaseStorage (8.15.0):
-    - FirebaseCore (~> 8.0)
-    - GTMSessionFetcher/Core (~> 1.5)
   - FirebaseMessaging (8.15.0):
     - FirebaseCore (~> 8.0)
     - FirebaseInstallations (~> 8.0)
@@ -691,6 +688,9 @@ PODS:
     - GoogleUtilities/Reachability (~> 7.7)
     - GoogleUtilities/UserDefaults (~> 7.7)
     - nanopb (~> 2.30908.0)
+  - FirebaseStorage (8.15.0):
+    - FirebaseCore (~> 8.0)
+    - GTMSessionFetcher/Core (~> 1.5)
   - GoogleAppMeasurement (8.15.0):
     - GoogleAppMeasurement/AdIdSupport (= 8.15.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 7.7)
@@ -827,8 +827,8 @@ DEPENDENCIES:
   - Firebase/Core
   - Firebase/Database
   - Firebase/Firestore
-  - FirebaseStorage
   - Firebase/Messaging
+  - FirebaseStorage
   - GoogleSignIn
   - KakaoSDKAuth
   - KakaoSDKCommon
@@ -850,8 +850,8 @@ SPEC REPOS:
     - FirebaseDatabase
     - FirebaseFirestore
     - FirebaseInstallations
-    - FirebaseStorage
     - FirebaseMessaging
+    - FirebaseStorage
     - GoogleAppMeasurement
     - GoogleDataTransport
     - GoogleSignIn
@@ -883,8 +883,8 @@ SPEC CHECKSUMS:
   FirebaseDatabase: f567afd233e54a303d84423207736590a6feb419
   FirebaseFirestore: d7023faff8e1b4fd69d0adbcf18e65129bc03842
   FirebaseInstallations: 40bd9054049b2eae9a2c38ef1c3dd213df3605cd
-  FirebaseStorage: 8019af461599b2c3bc61c6a5dbdfa3d2de66a4d9
   FirebaseMessaging: 5e5118a2383b3531e730d974680954c679ca0a13
+  FirebaseStorage: 8019af461599b2c3bc61c6a5dbdfa3d2de66a4d9
   GoogleAppMeasurement: 4c19f031220c72464d460c9daa1fb5d1acce958e
   GoogleDataTransport: 629c20a4d363167143f30ea78320d5a7eb8bd940
   GoogleSignIn: c90b5bec45e780f54c6a8e1e3c182a86e3dda69d
@@ -903,7 +903,6 @@ SPEC CHECKSUMS:
   SDWebImage: a47aea9e3d8816015db4e523daff50cfd294499d
   SnapKit: e01d52ebb8ddbc333eefe2132acf85c8227d9c25
 
-PODFILE CHECKSUM: ee0b7d0c09ef2912b02d4dcb4d4a1616df36b9f2
-PODFILE CHECKSUM: 08122eacea5d542dabcbebabe48cb7ca5e2c0018
+PODFILE CHECKSUM: e9f70d589919e1eaeef7c0f988b9447a11ebb617
 
-COCOAPODS: 1.11.2
+COCOAPODS: 1.11.3

--- a/TUDY.xcodeproj/project.pbxproj
+++ b/TUDY.xcodeproj/project.pbxproj
@@ -39,6 +39,8 @@
 		D8166C55285AEA0F005CAA70 /* HomeCoordinatorDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8166C54285AEA0F005CAA70 /* HomeCoordinatorDelegate.swift */; };
 		D83412962852D8BF00D1D835 /* TopBarCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D83412952852D8BF00D1D835 /* TopBarCell.swift */; };
 		D83412982852E1F200D1D835 /* GroupChatListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D83412972852E1F200D1D835 /* GroupChatListCell.swift */; };
+		D838D660287C086C009BE873 /* FirebaseFCMToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = D838D65F287C086C009BE873 /* FirebaseFCMToken.swift */; };
+		D838D662287C08D0009BE873 /* FCMToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = D838D661287C08D0009BE873 /* FCMToken.swift */; };
 		D83B7346285A1B45001ADEE2 /* FirebaseUserChatInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = D83B7345285A1B45001ADEE2 /* FirebaseUserChatInfo.swift */; };
 		D847DFFE283F2B3C00BB4E08 /* UIButton+Custom.swift in Sources */ = {isa = PBXBuildFile; fileRef = D847DFFD283F2B3C00BB4E08 /* UIButton+Custom.swift */; };
 		D847E000283F4B9600BB4E08 /* LoginCheckDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D847DFFF283F4B9600BB4E08 /* LoginCheckDelegate.swift */; };
@@ -152,6 +154,8 @@
 		D8166C54285AEA0F005CAA70 /* HomeCoordinatorDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeCoordinatorDelegate.swift; sourceTree = "<group>"; };
 		D83412952852D8BF00D1D835 /* TopBarCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopBarCell.swift; sourceTree = "<group>"; };
 		D83412972852E1F200D1D835 /* GroupChatListCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupChatListCell.swift; sourceTree = "<group>"; };
+		D838D65F287C086C009BE873 /* FirebaseFCMToken.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirebaseFCMToken.swift; sourceTree = "<group>"; };
+		D838D661287C08D0009BE873 /* FCMToken.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FCMToken.swift; sourceTree = "<group>"; };
 		D83B7345285A1B45001ADEE2 /* FirebaseUserChatInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirebaseUserChatInfo.swift; sourceTree = "<group>"; };
 		D847DFFD283F2B3C00BB4E08 /* UIButton+Custom.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIButton+Custom.swift"; sourceTree = "<group>"; };
 		D847DFFF283F4B9600BB4E08 /* LoginCheckDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginCheckDelegate.swift; sourceTree = "<group>"; };
@@ -261,6 +265,7 @@
 			isa = PBXGroup;
 			children = (
 				4AB16F0B2844F3F500EB36A6 /* User.swift */,
+				D838D661287C08D0009BE873 /* FCMToken.swift */,
 				D8923B25285A063300233E64 /* UserChatInfo.swift */,
 				4AB16F0D2844F40000EB36A6 /* Project.swift */,
 				D87CBB59284477D4003397A5 /* SubwayDataManager.swift */,
@@ -437,6 +442,7 @@
 				D8034E902857356A008C569F /* FirebaseChat.swift */,
 				D8C0266528599B93004CACFF /* FirebaseRealtimeChat.swift */,
 				D8F2FEB9285DA309002089DD /* FirebaseStorage.swift */,
+				D838D65F287C086C009BE873 /* FirebaseFCMToken.swift */,
 				4ABDB4EB286C247E009200C5 /* FirestoreChat.swift */,
 			);
 			path = Repositories;
@@ -956,6 +962,7 @@
 				D8C53A80284B595D000E7170 /* LoginCoordinatorDelegate.swift in Sources */,
 				FFD4624C2834BB13002A2022 /* HomeViewController.swift in Sources */,
 				4AB16F0E2844F40000EB36A6 /* Project.swift in Sources */,
+				D838D660287C086C009BE873 /* FirebaseFCMToken.swift in Sources */,
 				4AC095C72856EE7F0003BAFB /* UIViewController+Custom.swift in Sources */,
 				4AC095C928571D2E0003BAFB /* FirebaseProject.swift in Sources */,
 				D847E0042840B9F700BB4E08 /* UIToolbar+Custom.swift in Sources */,
@@ -963,6 +970,7 @@
 				D8E3794E283F22280051CDF1 /* SetInterestedJobViewController.swift in Sources */,
 				D893D318283B2EBC0057075F /* UIColor+Custom.swift in Sources */,
 				FFE69F3A285C17EE0015B858 /* HeartButton.swift in Sources */,
+				D838D662287C08D0009BE873 /* FCMToken.swift in Sources */,
 				D85ED4CB283E68CC00D0A006 /* LoginCoordinatorProtocol.swift in Sources */,
 				4AC095DD285B9B650003BAFB /* MessageCell.swift in Sources */,
 				D8C7F238283B986300424AE5 /* HomeCoordinatorProtocol.swift in Sources */,

--- a/TUDY/Models/FCMToken.swift
+++ b/TUDY/Models/FCMToken.swift
@@ -1,0 +1,23 @@
+//
+//  UserToken.swift
+//  TUDY
+//
+//  Created by neuli on 2022/07/11.
+//
+
+import Foundation
+
+struct FCMToken: Codable {
+    var userID: String
+    var fcmToken: String
+    
+    init(userID: String, fcmToken: String) {
+        self.userID = userID
+        self.fcmToken = fcmToken
+    }
+    
+    init(dict: [String : Any]) {
+        self.userID = dict["userID"] as? String ?? ""
+        self.fcmToken = dict["fcmToken"] as? String ?? ""
+    }
+}

--- a/TUDY/Presentations/Signup/TUDY/Presentations/Signup/ViewController/SetSubwayViewController.swift
+++ b/TUDY/Presentations/Signup/TUDY/Presentations/Signup/ViewController/SetSubwayViewController.swift
@@ -253,6 +253,11 @@ extension SetSubwayViewController {
                 print("유저 정보 DB 저장 실패 : \(error.localizedDescription)")
             }
         }
+        
+        if let token = UserDefaults.standard.object(forKey: "fcmToken") as? String {
+            FirebaseFCMToken.saveFCMToken(token: token)
+        }
+        
         didSendEventClosure?(.next)
     }
     

--- a/TUDY/Repositories/FirebaseFCMToken.swift
+++ b/TUDY/Repositories/FirebaseFCMToken.swift
@@ -1,0 +1,36 @@
+//
+//  FirebaseToken.swift
+//  TUDY
+//
+//  Created by neuli on 2022/07/11.
+//
+
+import Foundation
+import Firebase
+import FirebaseFirestore
+
+struct FirebaseFCMToken {
+    
+    private static let tokenPath = Firestore.firestore().collection("TOKEN")
+    
+    /// FCM 토큰 저장
+    static func saveFCMToken(token: String) {
+        
+        let userID = FirebaseUser.getUserID()
+        let fcmToken = FCMToken(userID: userID, fcmToken: token)
+        
+        let collectionListener = tokenPath.document(userID)
+        
+        guard let dictionary = fcmToken.asDictionary else {
+            print("[DEBUG] 토큰 데이터 로딩 실패")
+            return
+        }
+        
+        collectionListener.setData(dictionary) { error in
+            if let error = error {
+                print("파이어베이스 저장 에러 \(error.localizedDescription)")
+                return
+            }
+        }
+    }
+}

--- a/TUDY/Resource/AppDelegate.swift
+++ b/TUDY/Resource/AppDelegate.swift
@@ -8,11 +8,10 @@
 import UIKit
 
 import FirebaseCore
+import FirebaseAuth
 import KakaoSDKAuth
 import KakaoSDKCommon
 import FirebaseMessaging
-
-
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
@@ -77,6 +76,12 @@ extension AppDelegate: MessagingDelegate {
     func messaging(_ messaging: Messaging, didReceiveRegistrationToken fcmToken: String?) {
         print("AppDelegate - 파이어베이스 토큰을 받았다.")
         print("AppDelegate - Firebase registration token: \(String(describing: fcmToken))")
+        
+        UserDefaults.standard.set(fcmToken, forKey: "fcmToken")
+        
+        if let _ = Auth.auth().currentUser, let fcmToken = fcmToken {
+            FirebaseFCMToken.saveFCMToken(token: fcmToken)
+        }
     }
     
 }

--- a/TUDY/Resource/AppDelegate.swift
+++ b/TUDY/Resource/AppDelegate.swift
@@ -10,6 +10,9 @@ import UIKit
 import FirebaseCore
 import KakaoSDKAuth
 import KakaoSDKCommon
+import FirebaseMessaging
+
+
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
@@ -17,8 +20,39 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
         FirebaseApp.configure()
+        
+        // 원격 알림 등록
+        if #available(iOS 10.0, *) {
+          // For iOS 10 display notification (sent via APNS)
+          UNUserNotificationCenter.current().delegate = self
+
+          let authOptions: UNAuthorizationOptions = [.alert, .badge, .sound]
+          UNUserNotificationCenter.current().requestAuthorization(
+            options: authOptions,
+            completionHandler: { _, _ in }
+          )
+        } else {
+          let settings: UIUserNotificationSettings =
+            UIUserNotificationSettings(types: [.alert, .badge, .sound], categories: nil)
+          application.registerUserNotificationSettings(settings)
+        }
+
+        application.registerForRemoteNotifications()
+        
+        // 메세지 델리게이트
+        Messaging.messaging().delegate = self
+        
+        // 푸시 포그라운드 설정
+        UNUserNotificationCenter.current().delegate = self
+        
+        
         KakaoSDK.initSDK(appKey: "819b58a0b772d8512220712cfe65b437")
         return true
+    }
+    
+    // fcm 토큰 등록 되었을 때, firebase apns토큰과 연결 
+    func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
+        Messaging.messaging().apnsToken = deviceToken
     }
 
     // MARK: UISceneSession Lifecycle
@@ -35,4 +69,38 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 
 
+}
+
+extension AppDelegate: MessagingDelegate {
+    
+    // fcm 등록 토큰을 받았을 때
+    func messaging(_ messaging: Messaging, didReceiveRegistrationToken fcmToken: String?) {
+        print("AppDelegate - 파이어베이스 토큰을 받았다.")
+        print("AppDelegate - Firebase registration token: \(String(describing: fcmToken))")
+    }
+    
+}
+
+
+
+extension AppDelegate: UNUserNotificationCenterDelegate {
+    
+    // 푸시메세지가 앱이 켜저 있을 때 나올 때
+    func userNotificationCenter(_ center: UNUserNotificationCenter, willPresent notification: UNNotification, withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
+        
+        let userInfo = notification.request.content.userInfo
+        
+        print("willPresent: userInfo : ", userInfo)
+        
+        completionHandler([.banner, .sound, .badge])
+        
+    }
+    
+    // 푸시메세지를 받았을 때
+    func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void) {
+        
+        let userInfo = response.notification.request.content.userInfo
+        print("didReceive: userInfo : ", userInfo)
+        completionHandler()
+    }
 }

--- a/TUDY/TUDY.entitlements
+++ b/TUDY/TUDY.entitlements
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>aps-environment</key>
+	<string>development</string>
 	<key>com.apple.developer.applesignin</key>
 	<array>
 		<string>Default</string>


### PR DESCRIPTION
## 개요
- #102 

## 작업사항
- FCM 토큰을 userID로 바로 가져올 수 있도록 저장하는 코드를 추가했습니다.
- 앱 실행시 로그인 되어있다면 바로 저장
- 회원가입을 해야한다면 회원가입 후 저장 (UserDefaults에 저장해뒀다가)

<img width="1004" alt="image" src="https://user-images.githubusercontent.com/39167842/178256169-479c49a8-fbab-4356-bb60-9689103827f5.png">
