### PR TITLE
푸시알림 FCM RestAPI 전송 (테스트 필요)

### DIFF
--- a/TUDY.xcodeproj/project.pbxproj
+++ b/TUDY.xcodeproj/project.pbxproj
@@ -44,6 +44,8 @@
 		D838D660287C086C009BE873 /* FirebaseFCMToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = D838D65F287C086C009BE873 /* FirebaseFCMToken.swift */; };
 		D838D662287C08D0009BE873 /* FCMToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = D838D661287C08D0009BE873 /* FCMToken.swift */; };
 		D838D664287D3438009BE873 /* FCMDataManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D838D663287D3438009BE873 /* FCMDataManager.swift */; };
+		D838D666287E9DA1009BE873 /* Notification.swift in Sources */ = {isa = PBXBuildFile; fileRef = D838D665287E9DA1009BE873 /* Notification.swift */; };
+		D838D668287E9E05009BE873 /* MessageRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = D838D667287E9E05009BE873 /* MessageRequest.swift */; };
 		D83B7346285A1B45001ADEE2 /* FirebaseUserChatInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = D83B7345285A1B45001ADEE2 /* FirebaseUserChatInfo.swift */; };
 		D847DFFE283F2B3C00BB4E08 /* UIButton+Custom.swift in Sources */ = {isa = PBXBuildFile; fileRef = D847DFFD283F2B3C00BB4E08 /* UIButton+Custom.swift */; };
 		D847E000283F4B9600BB4E08 /* LoginCheckDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D847DFFF283F4B9600BB4E08 /* LoginCheckDelegate.swift */; };
@@ -162,6 +164,8 @@
 		D838D65F287C086C009BE873 /* FirebaseFCMToken.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirebaseFCMToken.swift; sourceTree = "<group>"; };
 		D838D661287C08D0009BE873 /* FCMToken.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FCMToken.swift; sourceTree = "<group>"; };
 		D838D663287D3438009BE873 /* FCMDataManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FCMDataManager.swift; sourceTree = "<group>"; };
+		D838D665287E9DA1009BE873 /* Notification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Notification.swift; sourceTree = "<group>"; };
+		D838D667287E9E05009BE873 /* MessageRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageRequest.swift; sourceTree = "<group>"; };
 		D83B7345285A1B45001ADEE2 /* FirebaseUserChatInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirebaseUserChatInfo.swift; sourceTree = "<group>"; };
 		D847DFFD283F2B3C00BB4E08 /* UIButton+Custom.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIButton+Custom.swift"; sourceTree = "<group>"; };
 		D847DFFF283F4B9600BB4E08 /* LoginCheckDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginCheckDelegate.swift; sourceTree = "<group>"; };
@@ -281,6 +285,8 @@
 				D89615E32849E55300C86130 /* ChatInfo.swift */,
 				FFC79E2C28581D1C00E2A0DC /* UserInfo.swift */,
 				D8C0266128595C1F004CACFF /* Message.swift */,
+				D838D665287E9DA1009BE873 /* Notification.swift */,
+				D838D667287E9E05009BE873 /* MessageRequest.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -950,6 +956,7 @@
 				D83B7346285A1B45001ADEE2 /* FirebaseUserChatInfo.swift in Sources */,
 				D8DD5C53286ED1E600B863D9 /* FastSearchViewController.swift in Sources */,
 				FFC658452848FA50008889C2 /* OptionSelectionBar.swift in Sources */,
+				D838D666287E9DA1009BE873 /* Notification.swift in Sources */,
 				FFBECD232850D8550092B524 /* DevelopCell.swift in Sources */,
 				D8C7F23A283B98B900424AE5 /* AppCoordinatorProtocol.swift in Sources */,
 				FF85A4F22850823500DB124E /* ProjectConditionsViewController.swift in Sources */,
@@ -967,6 +974,7 @@
 				D8F2FEBA285DA30A002089DD /* FirebaseStorage.swift in Sources */,
 				4AC095C5285116150003BAFB /* WorkCell.swift in Sources */,
 				4AB16F0C2844F3F500EB36A6 /* User.swift in Sources */,
+				D838D668287E9E05009BE873 /* MessageRequest.swift in Sources */,
 				D87CBB4A28432075003397A5 /* JobCell.swift in Sources */,
 				D87CBB5428439F4B003397A5 /* DetailJobButton.swift in Sources */,
 				4ACA6890287D00D7004706D4 /* NewCustomInputAccessoryView.swift in Sources */,

--- a/TUDY.xcodeproj/project.pbxproj
+++ b/TUDY.xcodeproj/project.pbxproj
@@ -44,7 +44,7 @@
 		D838D660287C086C009BE873 /* FirebaseFCMToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = D838D65F287C086C009BE873 /* FirebaseFCMToken.swift */; };
 		D838D662287C08D0009BE873 /* FCMToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = D838D661287C08D0009BE873 /* FCMToken.swift */; };
 		D838D664287D3438009BE873 /* FCMDataManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D838D663287D3438009BE873 /* FCMDataManager.swift */; };
-		D838D666287E9DA1009BE873 /* Notification.swift in Sources */ = {isa = PBXBuildFile; fileRef = D838D665287E9DA1009BE873 /* Notification.swift */; };
+		D838D666287E9DA1009BE873 /* NotificationInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = D838D665287E9DA1009BE873 /* NotificationInfo.swift */; };
 		D838D668287E9E05009BE873 /* MessageRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = D838D667287E9E05009BE873 /* MessageRequest.swift */; };
 		D83B7346285A1B45001ADEE2 /* FirebaseUserChatInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = D83B7345285A1B45001ADEE2 /* FirebaseUserChatInfo.swift */; };
 		D847DFFE283F2B3C00BB4E08 /* UIButton+Custom.swift in Sources */ = {isa = PBXBuildFile; fileRef = D847DFFD283F2B3C00BB4E08 /* UIButton+Custom.swift */; };
@@ -164,7 +164,7 @@
 		D838D65F287C086C009BE873 /* FirebaseFCMToken.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirebaseFCMToken.swift; sourceTree = "<group>"; };
 		D838D661287C08D0009BE873 /* FCMToken.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FCMToken.swift; sourceTree = "<group>"; };
 		D838D663287D3438009BE873 /* FCMDataManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FCMDataManager.swift; sourceTree = "<group>"; };
-		D838D665287E9DA1009BE873 /* Notification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Notification.swift; sourceTree = "<group>"; };
+		D838D665287E9DA1009BE873 /* NotificationInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationInfo.swift; sourceTree = "<group>"; };
 		D838D667287E9E05009BE873 /* MessageRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageRequest.swift; sourceTree = "<group>"; };
 		D83B7345285A1B45001ADEE2 /* FirebaseUserChatInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirebaseUserChatInfo.swift; sourceTree = "<group>"; };
 		D847DFFD283F2B3C00BB4E08 /* UIButton+Custom.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIButton+Custom.swift"; sourceTree = "<group>"; };
@@ -285,7 +285,7 @@
 				D89615E32849E55300C86130 /* ChatInfo.swift */,
 				FFC79E2C28581D1C00E2A0DC /* UserInfo.swift */,
 				D8C0266128595C1F004CACFF /* Message.swift */,
-				D838D665287E9DA1009BE873 /* Notification.swift */,
+				D838D665287E9DA1009BE873 /* NotificationInfo.swift */,
 				D838D667287E9E05009BE873 /* MessageRequest.swift */,
 			);
 			path = Models;
@@ -956,7 +956,7 @@
 				D83B7346285A1B45001ADEE2 /* FirebaseUserChatInfo.swift in Sources */,
 				D8DD5C53286ED1E600B863D9 /* FastSearchViewController.swift in Sources */,
 				FFC658452848FA50008889C2 /* OptionSelectionBar.swift in Sources */,
-				D838D666287E9DA1009BE873 /* Notification.swift in Sources */,
+				D838D666287E9DA1009BE873 /* NotificationInfo.swift in Sources */,
 				FFBECD232850D8550092B524 /* DevelopCell.swift in Sources */,
 				D8C7F23A283B98B900424AE5 /* AppCoordinatorProtocol.swift in Sources */,
 				FF85A4F22850823500DB124E /* ProjectConditionsViewController.swift in Sources */,

--- a/TUDY/Models/MessageRequest.swift
+++ b/TUDY/Models/MessageRequest.swift
@@ -9,12 +9,12 @@ import Foundation
 
 struct MessageRequest<T: Codable>: Codable {
     private var to: String
-    private var notification: Notification
+    private var notificationInfo: NotificationInfo
     private var data: T
     
     init(title: String, body: String, data: T, to: String) {
         self.to = to
-        self.notification = Notification(title: title, body: body)
+        self.notificationInfo = NotificationInfo(title: title, body: body)
         self.data = data
     }
 }

--- a/TUDY/Models/MessageRequest.swift
+++ b/TUDY/Models/MessageRequest.swift
@@ -1,0 +1,20 @@
+//
+//  MessageRequest.swift
+//  TUDY
+//
+//  Created by neuli on 2022/07/13.
+//
+
+import Foundation
+
+struct MessageRequest<T: Codable>: Codable {
+    private var to: String
+    private var notification: Notification
+    private var data: T
+    
+    init(title: String, body: String, data: T, to: String) {
+        self.to = to
+        self.notification = Notification(title: title, body: body)
+        self.data = data
+    }
+}

--- a/TUDY/Models/Notification.swift
+++ b/TUDY/Models/Notification.swift
@@ -1,0 +1,18 @@
+//
+//  Notification.swift
+//  TUDY
+//
+//  Created by neuli on 2022/07/13.
+//
+
+import Foundation
+
+struct Notification: Codable {
+    private var title: String
+    private var body: String
+    
+    init(title: String, body: String) {
+        self.title = title
+        self.body = body
+    }
+}

--- a/TUDY/Models/NotificationInfo.swift
+++ b/TUDY/Models/NotificationInfo.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct Notification: Codable {
+struct NotificationInfo: Codable {
     private var title: String
     private var body: String
     

--- a/TUDY/Repositories/FCMDataManager.swift
+++ b/TUDY/Repositories/FCMDataManager.swift
@@ -13,7 +13,7 @@ final class FCMDataManager {
     private static let urlString = "https://fcm.googleapis.com/fcm/send"
     
     // 숨겨야함
-    private static let serverKey = "AAAA-cFoBYI:APA91bE9fYLhVEGxP7i24YJtKRZEuqBq-ab5t7T5lGrZMnRX0tZS3wlqbmEx0h9GihJLD1C-wYh8G0AhiyV8lM3xgX-uyDoG4SaWimUK0ljwsdHj36ckj8uvulZlO_Nid10uhTYvBtIJ"
+    private static let serverKey = "key=AAAA-cFoBYI:APA91bE9fYLhVEGxP7i24YJtKRZEuqBq-ab5t7T5lGrZMnRX0tZS3wlqbmEx0h9GihJLD1C-wYh8G0AhiyV8lM3xgX-uyDoG4SaWimUK0ljwsdHj36ckj8uvulZlO_Nid10uhTYvBtIJ"
     
     private static func sendNotification(messageRequest: MessageRequest<Message>, completion: @escaping (Result<Data, NetworkError>) -> Void) {
         

--- a/TUDY/Repositories/FCMDataManager.swift
+++ b/TUDY/Repositories/FCMDataManager.swift
@@ -73,7 +73,8 @@ final class FCMDataManager {
             case .success:
                 return
             case .failure(let error):
-                print("메세지 알림 전송 에러: \(error.localizedDescription)")
+                guard let errorDescription = error.errorDescription else { return }
+                print("메세지 알림 전송 에러: \(errorDescription)")
                 return
             }
         }

--- a/TUDY/Repositories/FCMDataManager.swift
+++ b/TUDY/Repositories/FCMDataManager.swift
@@ -10,5 +10,72 @@ import Foundation
 final class FCMDataManager {
     
     // MARK: - Properties
-    private let url = "https://fcm.googleapis.com/v1/projects/myproject-b5ae1/messages:send"
+    private static let urlString = "https://fcm.googleapis.com/fcm/send"
+    
+    // 숨겨야함
+    private static let serverKey = "AAAA-cFoBYI:APA91bE9fYLhVEGxP7i24YJtKRZEuqBq-ab5t7T5lGrZMnRX0tZS3wlqbmEx0h9GihJLD1C-wYh8G0AhiyV8lM3xgX-uyDoG4SaWimUK0ljwsdHj36ckj8uvulZlO_Nid10uhTYvBtIJ"
+    
+    private static func sendNotification(messageRequest: MessageRequest<Message>, completion: @escaping (Result<Data, NetworkError>) -> Void) {
+        
+        guard let url = URL(string: urlString) else {
+            completion(.failure(.invalidURL))
+            return
+        }
+        guard let httpBody = createPostPayload(from: messageRequest) else {
+            completion(.failure(.encodingError))
+            return
+        }
+        
+        var request = URLRequest(url: url)
+        request.httpMethod = "post"
+        request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.addValue("application/json", forHTTPHeaderField: "Accept")
+        request.addValue(serverKey, forHTTPHeaderField: "Authorization")
+        request.httpBody = httpBody
+        
+        URLSession.shared.dataTask(with: request) { data, response, error in
+            guard let httpResponse = response as? HTTPURLResponse else {
+                completion(.failure(.unknownError))
+                return
+            }
+            if let _ = error {
+                completion(.failure(.httpError(errorCode: httpResponse.statusCode)))
+                return
+            }
+            guard 200...299 ~= httpResponse.statusCode else {
+                completion(.failure(.httpError(errorCode: httpResponse.statusCode)))
+                return
+            }
+            guard let data = data else {
+                completion(.failure(.missingDataError))
+                return
+            }
+            completion(.success(data))
+        }.resume()
+    }
+    
+    private static func createPostPayload<T: Codable>(from requestBody: T) -> Data? {
+        if let data = requestBody as? Data {
+            return data
+        }
+        return try? JSONEncoder().encode(requestBody)
+    }
+    
+    static func sendMessage(_ message: Message, fcmToken: String) {
+        let messageRequest = MessageRequest(
+            title: message.sender.nickname,
+            body: message.content,
+            data: message,
+            to: fcmToken)
+        
+        sendNotification(messageRequest: messageRequest) { result in
+            switch result {
+            case .success:
+                return
+            case .failure(let error):
+                print("메세지 알림 전송 에러: \(error.localizedDescription)")
+                return
+            }
+        }
+    }
 }

--- a/TUDY/Resource/AppDelegate.swift
+++ b/TUDY/Resource/AppDelegate.swift
@@ -6,6 +6,7 @@
 //
 
 import UIKit
+import UserNotifications
 
 import FirebaseCore
 import FirebaseAuth

--- a/TUDY/Util/Error/NetworkError.swift
+++ b/TUDY/Util/Error/NetworkError.swift
@@ -14,6 +14,8 @@ enum NetworkError: Error {
     case missingDataError
     case decodingError
     case encodingError
+    case unknownError
+    case httpError(errorCode: Int)
     
     var errorDescription: String? {
         switch self {
@@ -29,6 +31,10 @@ enum NetworkError: Error {
             return "디코딩에 실패하였습니다."
         case .encodingError:
             return "인코딩에 실패하였습니다."
+        case .unknownError:
+            return "알 수 없는 에러입니다."
+        case .httpError(let errorCode):
+            return "HTTP 에러코드: \(errorCode) 입니다."
         }
     }
 }


### PR DESCRIPTION
## 개요
- #102 

## 작업사항
- Rest api로 FCM에 푸시알림 전송 구현
- **테스트 필요!**

## 변경로직(optional)
- http v1 방식은 accessToken 가져오는 방식이 복잡해서.. http 방식으로 구현했습니다.
